### PR TITLE
Avoid altering previous state in reducers

### DIFF
--- a/app/reducers/root-reducer.js
+++ b/app/reducers/root-reducer.js
@@ -8,9 +8,11 @@ const initialState = {
 }
 
 export function addToSelectionById(id, state) {
+    var collection = [...state.collection];
+    var selection = [...state.selection];
     let targetItem = null;
 
-    state.collection = state.collection.filter((item) => {
+    collection = collection.filter((item) => {
         if (item.id === id) {
             targetItem = item;
 
@@ -20,15 +22,17 @@ export function addToSelectionById(id, state) {
         return true;
     });
 
-    state.selection.unshift(targetItem);
+    selection.unshift(targetItem);
 
-    return Object.assign({}, state);
+    return {...state, collection, selection};
 }
 
 export function removeFromSelectionById(id, state) {
+    var collection = [...state.collection];
+    var selection = [...state.selection];
     let targetItem = null;
 
-    state.selection = state.selection.filter((item) => {
+    selection = selection.filter((item) => {
         if (item.id === id) {
             targetItem = item;
             return false;
@@ -37,9 +41,9 @@ export function removeFromSelectionById(id, state) {
         return true;
     });
 
-    state.collection.unshift(targetItem);
+    collection.unshift(targetItem);
 
-    return Object.assign({}, state);
+    return {...state, collection, selection};
 }
 
 export function addDataToCollection(collection, state) {
@@ -49,22 +53,15 @@ export function addDataToCollection(collection, state) {
         return hash.hasOwnProperty(item.id) ? false : (hash[item.id] = true);
     });
 
-    state.collection = joinedCollection;
-    state.hasData = true;
-
-    return Object.assign({}, state);
+    return {...state, hasData: true, collection: joinedCollection};
 }
 
 export function showErrorMessage(message, state) {
-    state.failure = message;
-
-    return Object.assign({}, state);
+    return {...state, failure: message}
 }
 
 export function removeErrorMessage(state) {
-    state.failure = null;
-
-    return Object.assign({}, state);
+    return {...state, failure: null}
 }
 
 export function rootReducer(state = initialState, action) {


### PR DESCRIPTION
Hey @meanJim, awesome boilerplate! I learned a lot by looking at this, and finally understand the point of `bindActionCreators`, for one. Looking at it I saw one minor issue, which doesn't currently present a bug in your app but might confuse some people who are using this to learn. The rootReducer technically isn't pure, in that it alters the previous state as well as creating a new state object. If I play with the app with [redux devtools](https://www.npmjs.com/package/redux-devtools) the revert functionality doesn't play out as expected:
![devtools](https://cloud.githubusercontent.com/assets/210970/12940386/4111e4a8-cf7d-11e5-9b89-08bafc3cce97.gif)

The revert should bring the giphy feed back to its initial state, as well as wipe the selected images. This PR creates new arrays for selection and collection before altering them, which fixes the issue. I also don't know that this is the cleanest approach, but it's what's used in the [redux docs](https://rackt.org/redux/docs/basics/Reducers.html) (search for "We don’t mutate the state"). ImmutableJS is another solution but I understand wanting to reduce dependencies for a project like this.

I hope these comments make sense, if not I'm happy to try and better articulate what I'm getting at.

Thanks!
