### PR TITLE
Remove unnecessary path to gulp in run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "homepage": "https://github.com/meanJim/dough#readme",
   "license": "MIT",
   "scripts": {
-    "start": "./node_modules/.bin/gulp development",
-    "dev": "./node_modules/.bin/gulp development",
+    "start": "gulp development",
+    "dev": "gulp development",
     "build": "NODE_ENV=production gulp production"
   },
   "keywords": [


### PR DESCRIPTION
Via a [medium comment](https://medium.com/@timwis/i-do-this-too-f78d52e47900#.uxgbzs1ue) of all things, npm scripts add `node_modules/.bin` to the `PATH` so I don't think the explicit path is necessary. the script will also choose the local instance over any global gulp installation.
